### PR TITLE
Fix typo on the world `directory`

### DIFF
--- a/System/Posix/Directory/ByteString.hsc
+++ b/System/Posix/Directory/ByteString.hsc
@@ -45,7 +45,7 @@ module System.Posix.Directory.ByteString (
    seekDirStream,
 #endif
 
-   -- * The working dirctory
+   -- * The working directory
    getWorkingDirectory,
    changeWorkingDirectory,
    changeWorkingDirectoryFd,


### PR DESCRIPTION
Corrects a small typo found while [reading the docs](https://downloads.haskell.org/~ghc/8.2.1/docs/html/libraries/unix-2.7.2.2/System-Posix-Directory.html).
